### PR TITLE
test: 카테고리 테스트 코드 추가

### DIFF
--- a/src/main/java/com/example/toongallery/domain/category/service/CategoryService.java
+++ b/src/main/java/com/example/toongallery/domain/category/service/CategoryService.java
@@ -32,7 +32,7 @@ public class CategoryService {
         Category category = getCategoryEntity(categoryId);
 
         if (request.getCategoryName() != null && !request.getCategoryName().isBlank()
-                && !category.getCategoryName().equals(request.getCategoryName())) {
+                && !category.getCategoryName().equals(request.getCategoryName().toUpperCase())) {
 
             isDuplicatedName(request.getCategoryName());
             category.updateCategoryName(request.getCategoryName().toUpperCase());
@@ -65,7 +65,7 @@ public class CategoryService {
     }
 
     private void isDuplicatedName(String categoryName) {
-        if (categoryRepository.existsByCategoryName(categoryName)) {
+        if (categoryRepository.existsByCategoryName(categoryName.toUpperCase())) {
             throw new BaseException(ErrorCode.DUPLICATE_CATEGORY_NAME, categoryName);
         }
     }

--- a/src/main/java/com/example/toongallery/domain/webtoon/service/WebtoonService.java
+++ b/src/main/java/com/example/toongallery/domain/webtoon/service/WebtoonService.java
@@ -17,8 +17,8 @@ import com.example.toongallery.domain.webtoon.entity.Webtoon;
 import com.example.toongallery.domain.webtoon.entity.WebtoonViewLog;
 import com.example.toongallery.domain.webtoon.enums.WebtoonStatus;
 import com.example.toongallery.domain.webtoon.repository.WebtoonRepository;
-import com.example.toongallery.domain.webtooncategory.service.WebtoonCategoryService;
 import com.example.toongallery.domain.webtoon.repository.WebtoonViewLogRepository;
+import com.example.toongallery.domain.webtooncategory.service.WebtoonCategoryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
@@ -33,10 +33,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.Collections;
 import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -146,8 +144,6 @@ public class WebtoonService {
         Page<Webtoon> webtoons = webtoonRepository.findAll(pageable);
 
         return webtoons.map(webtoon -> {
-
-            Integer cachedViews = getCurrentViewCount(webtoon.getId());
 
             List<String> authorNames = authorService.getAuthorNamesByWebtoonId(webtoon.getId());
             

--- a/src/test/java/com/example/toongallery/domain/category/service/CategoryServiceTest.java
+++ b/src/test/java/com/example/toongallery/domain/category/service/CategoryServiceTest.java
@@ -1,0 +1,245 @@
+package com.example.toongallery.domain.category.service;
+
+import com.example.toongallery.domain.category.dto.request.CategoryRequest;
+import com.example.toongallery.domain.category.dto.response.CategoryResponse;
+import com.example.toongallery.domain.category.entity.Category;
+import com.example.toongallery.domain.category.repository.CategoryRepository;
+import com.example.toongallery.domain.common.exception.BaseException;
+import com.example.toongallery.domain.common.exception.ErrorCode;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CategoryServiceTest {
+
+    @Mock
+    private CategoryRepository categoryRepository;
+
+    @InjectMocks
+    private CategoryService categoryService;
+
+    @Test
+    void createCategory_성공() {
+        //given
+        String name = "comedy";
+        CategoryRequest request = new CategoryRequest();
+        ReflectionTestUtils.setField(request, "categoryName", name);
+
+
+        // 대문자로 변환 후 DB에 있는지 검사
+        when(categoryRepository.existsByCategoryName(name.toUpperCase())).thenReturn(false);
+
+        when(categoryRepository.save(any(Category.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        //when
+        CategoryResponse response = categoryService.createCategory(request);
+
+        //then
+        assertEquals("COMEDY", response.getCategoryName());
+        verify(categoryRepository).save(any(Category.class));
+    }
+
+    @Test
+    void createCategory_실패_중복이름일때(){
+        //given
+        String name = "comedy";
+        CategoryRequest request = new CategoryRequest();
+        ReflectionTestUtils.setField(request, "categoryName", name);
+
+        // 대문자로 변환 후 DB에 있는지 검사
+        when(categoryRepository.existsByCategoryName(name.toUpperCase())).thenReturn(true);
+
+        // when & then
+        BaseException exception = assertThrows(BaseException.class, () -> {
+            categoryService.createCategory(request);
+        });
+
+        assertEquals(ErrorCode.DUPLICATE_CATEGORY_NAME, exception.getErrorCode());
+        assertEquals(name, exception.getField()); // 예외 메시지에 들어간 값
+        verify(categoryRepository, never()).save(any()); // 저장 시도되지 않아야 함
+    }
+
+    @Test
+    void updateCategory_성공() {
+        // given
+        Long categoryId = 1L;
+        String originalName = "COMEDY";
+        String newName = "action";
+
+        CategoryRequest request = new CategoryRequest();
+        ReflectionTestUtils.setField(request, "categoryName", newName);
+        Category category = Category.of(originalName);
+
+        when(categoryRepository.findById(categoryId)).thenReturn(Optional.of(category));
+        when(categoryRepository.existsByCategoryName(newName.toUpperCase())).thenReturn(false);
+
+        // when
+        CategoryResponse response = categoryService.updateCategory(categoryId, request);
+
+        // then
+        assertEquals("ACTION", response.getCategoryName());
+        assertEquals("ACTION",category.getCategoryName());
+    }
+
+    @Test
+    void updateCategory_성공_동일한이름이면변경안함() {
+        // given
+        Long categoryId = 1L;
+        String name = "COMEDY";
+
+        CategoryRequest request = new CategoryRequest();
+        ReflectionTestUtils.setField(request, "categoryName", name);
+
+        Category category = Category.of(name);
+
+        when(categoryRepository.findById(categoryId)).thenReturn(Optional.of(category));
+
+        // when
+        CategoryResponse response = categoryService.updateCategory(categoryId, request);
+
+        // then
+        assertEquals("COMEDY", response.getCategoryName());
+        verify(categoryRepository, never()).existsByCategoryName(any()); // 중복 검사 안 했는지 확인
+    }
+
+    @Test
+    void updateCategory_실패_중복된이름() {
+        // given
+        Long categoryId = 1L;
+        String originalName = "COMEDY";
+        String newName = "action";
+
+        CategoryRequest request = new CategoryRequest();
+        ReflectionTestUtils.setField(request, "categoryName", newName);
+        Category category = Category.of(originalName);
+
+        when(categoryRepository.findById(categoryId)).thenReturn(Optional.of(category));
+        when(categoryRepository.existsByCategoryName(newName.toUpperCase())).thenReturn(true);
+
+        // when & then
+        BaseException exception = assertThrows(BaseException.class, () ->
+                categoryService.updateCategory(categoryId, request));
+
+        assertEquals(ErrorCode.DUPLICATE_CATEGORY_NAME, exception.getErrorCode());
+        assertEquals(newName, exception.getField());
+    }
+
+    @Test
+    void updateCategory_실패_존재하지않는카테고리() {
+        // given
+        Long categoryId = 99L;
+        CategoryRequest request = new CategoryRequest();
+        ReflectionTestUtils.setField(request, "categoryName", "any");
+
+        when(categoryRepository.findById(categoryId)).thenReturn(Optional.empty());
+
+        // when & then
+        BaseException exception = assertThrows(BaseException.class, () -> {
+            categoryService.updateCategory(categoryId, request);
+        });
+
+        assertEquals(ErrorCode.CATEGORY_NOT_EXIST, exception.getErrorCode());
+    }
+
+    @Test
+    void deleteCategory_성공() {
+        //given
+        Long categoryId = 1L;
+        Category category = Category.of("COMEDY");
+
+        when(categoryRepository.findById(categoryId)).thenReturn(Optional.of(category));
+
+        // when
+        categoryService.deleteCategory(categoryId);
+
+        // then
+        verify(categoryRepository).delete(category);
+    }
+
+    @Test
+    void deleteCategory_실패_존재하지_않는_카테고리(){
+        //given
+        Long categoryId = 99L;
+        when(categoryRepository.findById(categoryId)).thenReturn(Optional.empty());
+
+        // when & then
+        BaseException exception = assertThrows(BaseException.class, () -> {
+            categoryService.deleteCategory(categoryId);
+        });
+
+        assertEquals(ErrorCode.CATEGORY_NOT_EXIST, exception.getErrorCode());
+    }
+
+    @Test
+    void getCategory_성공() {
+        // given
+        Long categoryId = 1L;
+        Category category = Category.of("COMEDY");
+        given(categoryRepository.findById(categoryId)).willReturn(Optional.of(category));
+
+        // when
+        CategoryResponse response = categoryService.getCategory(categoryId);
+
+        // then
+        assertEquals("COMEDY", response.getCategoryName());
+    }
+
+    @Test
+    void getCategory_실패_존재하지않는카테고리() {
+        // given
+        Long categoryId = 99L;
+        when(categoryRepository.findById(categoryId)).thenReturn(Optional.empty());
+
+        // when & then
+        BaseException exception = assertThrows(BaseException.class, () -> {
+            categoryService.getCategory(categoryId);
+        });
+
+        assertEquals(ErrorCode.CATEGORY_NOT_EXIST, exception.getErrorCode());
+    }
+
+    @Test
+    void getAllCategories_성공() {
+        // given
+        List<Category> categories = List.of(
+                Category.of("COMEDY"),
+                Category.of("ACTION")
+        );
+
+        when(categoryRepository.findAll()).thenReturn(categories);
+
+        // when
+        List<CategoryResponse> responses = categoryService.getAllCategories();
+
+        // then
+        assertEquals(2, responses.size());
+        assertEquals("COMEDY", responses.get(0).getCategoryName());
+        assertEquals("ACTION", responses.get(1).getCategoryName());
+    }
+
+    @Test
+    void getAllCategories_성공_빈리스트() {
+        // given
+        when(categoryRepository.findAll()).thenReturn(List.of());
+
+        // when
+        List<CategoryResponse> responses = categoryService.getAllCategories();
+
+        // then
+        assertEquals(0, responses.size());
+    }
+
+}

--- a/src/test/java/com/example/toongallery/domain/webtoon/service/WebtoonServiceTest.java
+++ b/src/test/java/com/example/toongallery/domain/webtoon/service/WebtoonServiceTest.java
@@ -1,0 +1,161 @@
+package com.example.toongallery.domain.webtoon.service;
+
+import com.example.toongallery.domain.author.service.AuthorService;
+import com.example.toongallery.domain.common.dto.AuthUser;
+import com.example.toongallery.domain.common.exception.BaseException;
+import com.example.toongallery.domain.common.exception.ErrorCode;
+import com.example.toongallery.domain.user.entity.User;
+import com.example.toongallery.domain.user.enums.Gender;
+import com.example.toongallery.domain.user.enums.UserRole;
+import com.example.toongallery.domain.user.repository.UserRepository;
+import com.example.toongallery.domain.webtoon.dto.request.WebtoonSaveRequest;
+import com.example.toongallery.domain.webtoon.dto.response.WebtoonResponse;
+import com.example.toongallery.domain.webtoon.entity.Webtoon;
+import com.example.toongallery.domain.webtoon.enums.DayOfWeek;
+import com.example.toongallery.domain.webtoon.enums.WebtoonStatus;
+import com.example.toongallery.domain.webtoon.repository.WebtoonRepository;
+import com.example.toongallery.domain.webtooncategory.service.WebtoonCategoryService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class WebtoonServiceTest {
+
+    @Mock private UserRepository userRepository;
+    @Mock private WebtoonRepository webtoonRepository;
+    @Mock private AuthorService authorService;
+    @Mock private WebtoonCategoryService webtoonCategoryService;
+    @InjectMocks private WebtoonService webtoonService;
+
+    @DisplayName("웹툰 저장 실패 - 로그인한 유저가 작가가 아님")
+    @Test
+    void saveWebtoon_실패_작성자가아님() {
+        // given
+        AuthUser authUser = new AuthUser(1L, "user@example.com", UserRole.ROLE_USER); // 작가 아님
+        WebtoonSaveRequest request = new WebtoonSaveRequest(
+                "웹툰 제목",
+                List.of("작가1"),
+                List.of("로맨스"),
+                "설명입니다",
+                DayOfWeek.MON
+        );
+        MultipartFile thumbnailFile = mock(MultipartFile.class);
+
+        User user = new User(
+                "user@example.com", "pw", "유저", LocalDate.now(), Gender.MALE, UserRole.ROLE_USER
+        );
+        when(userRepository.findByEmail("user@example.com")).thenReturn(Optional.of(user));
+
+        // when & then
+        BaseException ex = assertThrows(BaseException.class, () ->
+                webtoonService.saveWebtoon(authUser, request, thumbnailFile));
+
+        assertEquals(ErrorCode.INVALID_USER_ROLE, ex.getErrorCode());
+        assertEquals("작가만 웹툰 등록 가능", ex.getField());
+    }
+
+    @DisplayName("웹툰 저장 실패 - 작가 목록에 존재하지 않는 유저 포함")
+    @Test
+    void saveWebtoon_실패_존재하지않는작가() {
+        // given
+        AuthUser authUser = new AuthUser(1L, "author@example.com", UserRole.ROLE_AUTHOR);
+        WebtoonSaveRequest request = new WebtoonSaveRequest(
+                "웹툰 제목",
+                List.of("작가1", "작가2"),
+                List.of("로맨스"),
+                "설명입니다",
+                DayOfWeek.MON
+        );
+        MultipartFile thumbnailFile = mock(MultipartFile.class);
+
+        User authorUser = new User(
+                "author@example.com", "pw", "작가1", LocalDate.now(), Gender.MALE, UserRole.ROLE_AUTHOR
+        );
+
+        when(userRepository.findByEmail("author@example.com")).thenReturn(Optional.of(authorUser));
+        when(userRepository.findByNameIn(List.of("작가1", "작가2")))
+                .thenReturn(List.of(authorUser)); // 작가2 없음
+
+        // when & then
+        BaseException ex = assertThrows(BaseException.class, () ->
+                webtoonService.saveWebtoon(authUser, request, thumbnailFile));
+
+        assertEquals(ErrorCode.USER_NOT_FOUND, ex.getErrorCode());
+        assertTrue(ex.getField().contains("작가2")); // 누락된 작가 이름 포함 여부
+    }
+
+
+    @Test
+    @DisplayName("전체 웹툰 조회 - 작가, 카테고리 포함")
+    void getWebtoons_성공() {
+        // given
+        Webtoon webtoon1 = Webtoon.of("웹툰1", "thumb1.jpg", "설명1", DayOfWeek.MON, WebtoonStatus.ONGOING);
+        ReflectionTestUtils.setField(webtoon1, "id", 1L);
+
+        Webtoon webtoon2 = Webtoon.of("웹툰2", "thumb2.jpg", "설명2", DayOfWeek.TUE, WebtoonStatus.ONGOING);
+        ReflectionTestUtils.setField(webtoon2, "id", 2L);
+
+        Page<Webtoon> mockPage = new PageImpl<>(List.of(webtoon1, webtoon2));
+        when(webtoonRepository.findAll(any(Pageable.class))).thenReturn(mockPage);
+
+        when(authorService.getAuthorNamesByWebtoonId(1L)).thenReturn(List.of("작가A"));
+        when(authorService.getAuthorNamesByWebtoonId(2L)).thenReturn(List.of("작가B", "작가C"));
+
+        when(webtoonCategoryService.getCategoryNamesByWebtoonId(1L)).thenReturn(List.of("로맨스"));
+        when(webtoonCategoryService.getCategoryNamesByWebtoonId(2L)).thenReturn(List.of("액션", "판타지"));
+
+        // when
+        Page<WebtoonResponse> result = webtoonService.getWebtoons(1, 10);
+
+        // then
+        assertEquals(2, result.getContent().size());
+
+        WebtoonResponse w1 = result.getContent().get(0);
+        assertEquals("웹툰1", w1.getTitle());
+        assertEquals(List.of("작가A"), w1.getAuthors());
+        assertEquals(List.of("로맨스"), w1.getGenres());
+
+        WebtoonResponse w2 = result.getContent().get(1);
+        assertEquals("웹툰2", w2.getTitle());
+        assertEquals(List.of("작가B", "작가C"), w2.getAuthors());
+        assertEquals(List.of("액션", "판타지"), w2.getGenres());
+    }
+
+    @DisplayName("전체 웹툰 조회 - 결과 없음 (빈 페이지)")
+    @Test
+    void getWebtoons_빈결과() {
+        // given
+        Page<Webtoon> emptyPage = new PageImpl<>(List.of());
+        when(webtoonRepository.findAll(any(Pageable.class))).thenReturn(emptyPage);
+
+        // when
+        Page<WebtoonResponse> result = webtoonService.getWebtoons(1, 10);
+
+        // then
+        assertNotNull(result);
+        assertEquals(0, result.getContent().size());
+    }
+
+
+}


### PR DESCRIPTION
## 📌 What is this PR ?

카테고리 서비스 로직에 대한 테스트 코드를 작성하였습니다.

<br/>

## 🔎 Additions / Changes

## Additions
아래와 같은 테스트용 메서드를 작성하였습니다.
createCategory_성공
createCategory_실패_중복이름일때
getCategory_성공
getCategory_실패_존재하지않는카테고리
getAllCategories_성공
getAllCategories_성공_빈리스트
updateCategory_성공
updateCategory_성공_동일한이름이면변경안함
updateCategory_실패_중복된이름
updateCategory_실패_존재하지않는카테고리
deleteCategory_성공
deleteCategory_실패_존재하지_않는_카테고리
## Changes
CategoryServiceTest추가

<br/>

## 📷 Screenshot
해당 코드가 잘 실행되는 스크린샷을 남겨주세요

| 기능 | 스크린샷 |
| --- | --- |
| 카테고리 서비스 커버리지| ![image](https://github.com/user-attachments/assets/9575e90f-813b-4baf-bdc8-5ec45b4e3af2)|

<br/>

## ✅ Test Checklist
- [ ] 추가, 수정된 코드 부분에서
- [ ] 그의 테스트 체크한 내용을 작성해 주세요
